### PR TITLE
Make changes so the installer should work without python2 errors

### DIFF
--- a/open-lst/tools/install_python_tools.sh
+++ b/open-lst/tools/install_python_tools.sh
@@ -17,7 +17,7 @@
 
 sudo apt-get update
 sudo apt-get install --assume-yes python-dev python-pip
-sudo pip install -e /home/vagrant/project/open-lst/tools
+sudo python -m pip install -e /home/vagrant/project/open-lst/tools
 
 # Install the radio services
 sudo cp /home/vagrant/project/open-lst/tools/radio@.service /etc/systemd/system/radio@.service

--- a/open-lst/tools/setup.py
+++ b/open-lst/tools/setup.py
@@ -60,7 +60,7 @@ setup(name='openlst_tools',
       packages=['openlst_tools'],
       install_requires=[
           "blessed>=1.15.0,<2.0.0",
-          "pyzmq>=13.1.0",
-          "pycrypto>=2.6",
+          "pyzmq>=13.1.0,<14.0.0",
+          "pycrypto>=2.6,<2.7",
           "pyserial",
           "six"])


### PR DESCRIPTION
When using the `vagrant up` command, the initialization for the program fails with an ignorable error which leaves the python tools uninstalled on the VM when you launch it.  This pull request sets a maximum version on the python utilities so that they are all python 2 compatible and do not give syntax errors as currently happens.

In the future, it would probably be good to find the newest working versions and lock it to those.